### PR TITLE
bugfix: fix create contest button when not signed in

### DIFF
--- a/packages/react-app-revamp/hooks/useWallet/index.ts
+++ b/packages/react-app-revamp/hooks/useWallet/index.ts
@@ -24,7 +24,7 @@ interface WalletHookReturn {
  */
 export function useWallet(): WalletHookReturn {
   // Para SDK hooks for wallet state
-  const { connectionType, external, isConnected } = useAccount();
+  const { connectionType, external, isConnected: isAccountConnected } = useAccount();
   const { data: paraWallet } = useParaWallet(); // Only available for embedded wallets
   const { logout: paraLogout } = useLogout();
   const { openModal } = useModal();
@@ -47,6 +47,10 @@ export function useWallet(): WalletHookReturn {
     // Embedded wallet address comes from Para wallet
     return paraWallet?.address as `0x${string}` | undefined;
   }, [connectionType, external?.evm?.address, paraWallet?.address]);
+
+  // wagmi connection with an expired Para session reports
+  // isConnected without a resolvable address — treat that as signed out
+  const isConnected = isAccountConnected && !!userAddress;
 
   // Connection handler - returns existing promise if already connected
   const connect = async () => {


### PR DESCRIPTION
Closes #6172 

Ok this one was weird as i was prompted with para modal when i was not signed in the create flow, but i went on and deleted `keys` in the `localStorage` that are created by para when you are logged in.

When a Para session expires but wagmi silently auto-reconnects the external wallet on page load, Para's `useAccount` still reports `isConnected: true` while no address is resolvable, so "create contest" hit the deploy path and errored instead of opening the sign-in modal — useWallet now only reports connected when an address is actually resolved.