### PR TITLE
fix: guard against undefined contest title when contract call fails

### DIFF
--- a/packages/react-app-revamp/components/_pages/User/components/VotingList/components/List/index.tsx
+++ b/packages/react-app-revamp/components/_pages/User/components/VotingList/components/List/index.tsx
@@ -17,7 +17,7 @@ const UserVotesList: FC<UserVotesListProps> = ({ submission }) => {
       <p>
         The user cast <span className="text-positive-11 font-bold">{formatNumber(submission.vote_amount)}</span> vote
         {submission.vote_amount > 1 ? "s" : ""} for Proposal {submission.proposal_id.slice(0, 5)} in the{" "}
-        {submission.contest.title} contest.
+        {submission.contest.title || "an unnamed"} contest.
       </p>
     </div>
   );

--- a/packages/react-app-revamp/lib/contests/contracts.ts
+++ b/packages/react-app-revamp/lib/contests/contracts.ts
@@ -71,9 +71,9 @@ export async function getContestContractData(
       ],
     });
 
-    const title = results[0].result as string;
-    const state = results[1].result;
-    const prompt = results[2].result as string;
+    const title = results[0].status === "success" ? (results[0].result as string) : null;
+    const state = results[1].status === "success" ? results[1].result : undefined;
+    const prompt = results[2].status === "success" ? (results[2].result as string) : null;
     const isCanceled = state === ContestStateEnum.Canceled;
 
     return { title, isCanceled, prompt };


### PR DESCRIPTION
Fixes #6100

## Root Cause

`getContestContractData` uses `readContracts()` to batch-fetch a contest's `name`, `state`, and `prompt`.

When one of the calls fails (for example, `name()` reverts or is not supported by an older contract version), `readContracts()` does not throw an error. Instead, it returns:

* `status: "failure"`
* `result: undefined`

The existing code was directly casting `results[0].result` to `string` without checking the result status. This caused a failed `name()` call to silently produce `title: undefined`.

Downstream, `title ?? ""` converted the missing title into an empty string, resulting in user profiles displaying:

> `...in the contest.`

with the contest name missing.

## Fix

### `contracts.ts`

* Check `result.status === "success"` before using `title`, `state`, and `prompt`.
* Fall back to `null`/`undefined` when a multicall fails.
* Prevent failed contract reads from silently propagating `undefined`.

### `List/index.tsx`

* Added a UI-level fallback of `"an unnamed"` when the contest title is unavailable.
* This keeps the sentence readable even if the title is missing for another reason.

## Testing

I traced the issue through static analysis but was unable to fully reproduce it locally because the required Supabase/QuickNode environment keys are maintainer-only.

The fix can be verified against the reproduction steps in #6100.
