### PR TITLE
enhancement: add live for on contest card on landing page

### DIFF
--- a/packages/react-app-revamp/components/_pages/FeaturedContests/components/Contest/helpers.ts
+++ b/packages/react-app-revamp/components/_pages/FeaturedContests/components/Contest/helpers.ts
@@ -73,7 +73,7 @@ export const getContestTiming = (contest: ProcessedContest): ContestTimingData |
     const duration = moment.duration(end.diff(now));
     return {
       format: "countdown",
-      display: formatCountdown(duration),
+      display: `live for ${formatCountdown(duration)}`,
     };
   }
 


### PR DESCRIPTION
Closes #6259

It all fits nicely, so we can def attach this text when contest is in the voting phase

https://deploy-preview-6268--confetti-main.netlify.app/